### PR TITLE
Support for an additional EDNS client subnet for AAAA queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Usage of dingo-linux-amd64:
     	Google DNS: try to lookup the closest IPv4 server
   -gdns:edns string
     	Google DNS: EDNS client subnet (set 0.0.0.0/0 to disable)
+  -gdns:edns6 string
+    	Google DNS: Optional IPv6 EDNS client subnet for AAAA queries
   -gdns:host string
     	Google DNS: HTTP 'Host' header (real FQDN, encrypted in TLS) (default "dns.google.com")
   -gdns:nopad

--- a/gdns.go
+++ b/gdns.go
@@ -23,6 +23,7 @@ type Gdns struct {
 	sni *string
 	host *string
 	edns *string
+	edns6 *string
 	nopad *bool
 }
 
@@ -40,6 +41,8 @@ func (r *Gdns) Init() {
 		"Google DNS: HTTP 'Host' header (real FQDN, encrypted in TLS)")
 	r.edns    = flag.String("gdns:edns", "",
 		"Google DNS: EDNS client subnet (set 0.0.0.0/0 to disable)")
+	r.edns6    = flag.String("gdns:edns6", "",
+		"Google DNS: Optional IPv6 EDNS client subnet for AAAA queries")
 	r.nopad   = flag.Bool("gdns:nopad", false,
 		"Google DNS: disable random padding")
 }
@@ -76,9 +79,13 @@ func (R *Gdns) resolve(https *Https, server string, qname string, qtype int) *Re
 	/* prepare */
 	v.Set("name", qname)
 	v.Set("type", fmt.Sprintf("%d", qtype))
-	if len(*R.edns) > 0 {
+
+	if (qtype == 28 && len(*R.edns6) > 0) {
+		v.Set("edns_client_subnet", *R.edns6)
+	} else if (len(*R.edns) > 0) {
 		v.Set("edns_client_subnet", *R.edns)
 	}
+	
 	if !*R.nopad {
 		v.Set("random_padding", strings.Repeat(string(65+rand.Intn(26)), rand.Intn(500)))
 	}


### PR DESCRIPTION
It is useful on dual-stack connections with mixed AS-Numbers to specify both an IPv4 and IPv6 EDNS client subnet and use the IPv6 client subnet when asking for AAAA records. In that case, you would put your IPv4 subnet into ```-gdns:edns``` and your IPv6 subnet into ```-gdns:edns6```

I am not sure how useful this will be for most users, but it has advantages in my setup. I would like to hear feedback or please feel free to close/ignore this pull request if it is beyond dingos scope.