### PR TITLE
Security: Enforce highest known available and working Cipher in TLS Handshake for 256bit Encryption usage

### DIFF
--- a/https.go
+++ b/https.go
@@ -24,8 +24,13 @@ func NewHttps(sni string, forceh1 bool) *Https {
 	H := Https{}
 
 	/* TLS setup */
-	tlscfg := new(tls.Config)
-	tlscfg.ServerName = sni
+	tlscfg := &tls.Config{
+		ServerName: sni,
+		//Enforce highest known available Cipher
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305},
+		MinVersion: tls.VersionTLS12,
+	}
 
 	/* HTTP transport */
 	var tr http.RoundTripper


### PR DESCRIPTION
Higher Encryption.. Default: before was in My Test: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 ( 0xc02f)   ECDH x25519 (Gl. 3072 Bits RSA) FS